### PR TITLE
[Do-My-Best-02] Add: Main page Card Container

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,0 +1,6 @@
+interface AdvantageInformation {
+	categories: string[];
+	userName: string;
+}
+
+export type { AdvantageInformation };

--- a/src/components/UI/atoms/Avatar/Avatar.styles.ts
+++ b/src/components/UI/atoms/Avatar/Avatar.styles.ts
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+const AvatarWrapper = styled.div`
+	width: 70px;
+	height: 70px;
+	margin: 10px;
+
+	border-radius: 50%;
+	background-color: #c4c4c4;
+	overflow: hidden;
+`;
+
+export { AvatarWrapper };

--- a/src/components/UI/atoms/Avatar/Avatar.types.ts
+++ b/src/components/UI/atoms/Avatar/Avatar.types.ts
@@ -1,0 +1,8 @@
+import { CSSProperties } from 'react';
+
+interface AvatarProps {
+	image?: string;
+	style?: CSSProperties;
+}
+
+export type { AvatarProps };

--- a/src/components/UI/atoms/Avatar/index.tsx
+++ b/src/components/UI/atoms/Avatar/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+import type { AvatarProps } from './Avatar.types';
+import { AvatarWrapper } from './Avatar.styles';
+
+const Avatar = ({ image, style }: AvatarProps) => {
+	return <AvatarWrapper style={style}>{image && <img src={image} />}</AvatarWrapper>;
+};
+
+export default Avatar;

--- a/src/components/UI/atoms/Button/Button.styles.ts
+++ b/src/components/UI/atoms/Button/Button.styles.ts
@@ -4,6 +4,7 @@ const ButtonWrapper = styled.button`
 	width: 100px;
 	height: 20px;
 	padding: 0;
+	margin: 10px;
 
 	font-family: NanumGothic;
 	font-style: normal;

--- a/src/components/UI/atoms/Button/index.tsx
+++ b/src/components/UI/atoms/Button/index.tsx
@@ -4,7 +4,7 @@ import type { ButtonProps } from './Button.types';
 import { ButtonWrapper } from './Button.styles';
 
 const Button = ({ text, style }: ButtonProps) => {
-	return <ButtonWrapper style={{ ...style }}>{text}</ButtonWrapper>;
+	return <ButtonWrapper style={style}>{text}</ButtonWrapper>;
 };
 
 export default Button;

--- a/src/components/UI/atoms/CategoryLabel/CategoryLabel.styles.ts
+++ b/src/components/UI/atoms/CategoryLabel/CategoryLabel.styles.ts
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+
+const CategoryLabelWrapper = styled.div`
+	width: auto;
+	min-width: 60px;
+	height: 20px;
+	margin-right: 5px;
+
+	font-family: NanumGothic;
+	font-style: normal;
+	font-weight: bold;
+	font-size: 12px;
+
+	align-items: center;
+	text-align: center;
+	background-color: #0065ff;
+	color: #ffffff;
+
+	border-radius: 6px;
+`;
+
+export { CategoryLabelWrapper };

--- a/src/components/UI/atoms/CategoryLabel/CategoryLabel.types.ts
+++ b/src/components/UI/atoms/CategoryLabel/CategoryLabel.types.ts
@@ -1,0 +1,8 @@
+import { CSSProperties } from 'react';
+
+interface CategoryLabelProps {
+	text: string;
+	style?: CSSProperties;
+}
+
+export type { CategoryLabelProps };

--- a/src/components/UI/atoms/CategoryLabel/index.tsx
+++ b/src/components/UI/atoms/CategoryLabel/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+import type { CategoryLabelProps } from './CategoryLabel.types';
+import { CategoryLabelWrapper } from './CategoryLabel.styles';
+
+const CategoryLabel = ({ text, style }: CategoryLabelProps) => {
+	return <CategoryLabelWrapper style={style}>{text}</CategoryLabelWrapper>;
+};
+
+export default CategoryLabel;

--- a/src/components/UI/atoms/Label/Label.styles.ts
+++ b/src/components/UI/atoms/Label/Label.styles.ts
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+const LabelWrapper = styled.p`
+	color: #000000;
+
+	font-family: NanumGothic;
+	font-style: normal;
+	font-weight: bold;
+	font-size: 14px;
+`;
+
+export { LabelWrapper };

--- a/src/components/UI/atoms/Label/Label.types.ts
+++ b/src/components/UI/atoms/Label/Label.types.ts
@@ -1,5 +1,8 @@
+import { CSSProperties } from 'react';
+
 interface LabelProps {
 	text: string;
+	style?: CSSProperties;
 }
 
 export type { LabelProps };

--- a/src/components/UI/atoms/Label/index.tsx
+++ b/src/components/UI/atoms/Label/index.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
-import { LabelProps } from './Label.types';
+import type { LabelProps } from './Label.types';
+import { LabelWrapper } from './Label.styles';
 
-const Label = ({ text }: LabelProps) => {
-	return <p>{text}</p>;
+const Label = ({ text, style }: LabelProps) => {
+	return <LabelWrapper style={style}>{text}</LabelWrapper>;
 };
 
 export default Label;

--- a/src/components/UI/atoms/OnlyTextButton/OnlyTextButton.types.ts
+++ b/src/components/UI/atoms/OnlyTextButton/OnlyTextButton.types.ts
@@ -1,5 +1,8 @@
+import { CSSProperties } from 'react';
+
 interface OnlyTextButtonProps {
 	text: string;
+	style?: CSSProperties;
 }
 
 export type { OnlyTextButtonProps };

--- a/src/components/UI/atoms/OnlyTextButton/index.tsx
+++ b/src/components/UI/atoms/OnlyTextButton/index.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 import type { OnlyTextButtonProps } from './OnlyTextButton.types';
 import { OnlyTextButtonWrapper } from './OnlyTextButton.styles';
 
-const OnlyTextButton = ({ text }: OnlyTextButtonProps) => {
-	return <OnlyTextButtonWrapper>{text}</OnlyTextButtonWrapper>;
+const OnlyTextButton = ({ text, style }: OnlyTextButtonProps) => {
+	return <OnlyTextButtonWrapper style={style}>{text}</OnlyTextButtonWrapper>;
 };
 
 export default OnlyTextButton;

--- a/src/components/UI/molecules/CategoryLabelList/CategoryLabelList.styles.ts
+++ b/src/components/UI/molecules/CategoryLabelList/CategoryLabelList.styles.ts
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+const CategoryLabelListWrapper = styled.article`
+	display: flex;
+	justify-content: space-around;
+	width: 100%;
+
+	overflow: scroll;
+`;
+
+export { CategoryLabelListWrapper };

--- a/src/components/UI/molecules/CategoryLabelList/CategoryLabelList.types.ts
+++ b/src/components/UI/molecules/CategoryLabelList/CategoryLabelList.types.ts
@@ -1,0 +1,8 @@
+import { CSSProperties } from 'react';
+
+interface CategoryLabelListProps {
+	style?: CSSProperties;
+	categories: string[];
+}
+
+export type { CategoryLabelListProps };

--- a/src/components/UI/molecules/CategoryLabelList/index.tsx
+++ b/src/components/UI/molecules/CategoryLabelList/index.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import type { CategoryLabelListProps } from './CategoryLabelList.types';
+import { CategoryLabelListWrapper } from './CategoryLabelList.styles';
+
+import CategoryLabel from '@atoms/CategoryLabel';
+
+const CategoryLabelList = ({ style, categories }: CategoryLabelListProps) => {
+	return (
+		<CategoryLabelListWrapper style={style}>
+			{categories.map(category => (
+				<CategoryLabel text={category} />
+			))}
+		</CategoryLabelListWrapper>
+	);
+};
+
+export default CategoryLabelList;

--- a/src/components/UI/molecules/LabelButton/LabelButton.styles.ts
+++ b/src/components/UI/molecules/LabelButton/LabelButton.styles.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+const LabelButtonWrapper = styled.div`
+	display: flex;
+	justify-content: center;
+	align-items: center;
+`;
+
+export { LabelButtonWrapper };

--- a/src/components/UI/molecules/LabelButton/LabelButton.types.ts
+++ b/src/components/UI/molecules/LabelButton/LabelButton.types.ts
@@ -1,0 +1,11 @@
+import { CSSProperties } from 'react';
+
+interface LabelButtonProps {
+	buttonText: string;
+	labelText: string;
+	buttonStyle?: CSSProperties;
+	labelStyle?: CSSProperties;
+	wrapperStyle?: CSSProperties;
+}
+
+export type { LabelButtonProps };

--- a/src/components/UI/molecules/LabelButton/index.tsx
+++ b/src/components/UI/molecules/LabelButton/index.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import type { LabelButtonProps } from './LabelButton.types';
+import { LabelButtonWrapper } from './LabelButton.styles';
+
+import Button from '@atoms/Button';
+import Label from '@atoms/Label';
+
+const LabelButton = ({
+	buttonText,
+	labelText,
+	buttonStyle,
+	labelStyle,
+	wrapperStyle,
+}: LabelButtonProps) => {
+	return (
+		<LabelButtonWrapper style={wrapperStyle}>
+			<Label text={labelText} style={labelStyle} />
+			<Button text={buttonText} style={buttonStyle} />
+		</LabelButtonWrapper>
+	);
+};
+
+export default LabelButton;

--- a/src/components/UI/molecules/WideCard/WideCard.styles.ts
+++ b/src/components/UI/molecules/WideCard/WideCard.styles.ts
@@ -1,0 +1,34 @@
+import styled from 'styled-components';
+
+const WideCardWrapper = styled.article`
+	display: flex;
+	align-items: center;
+	width: 450px;
+	height: 85px;
+	margin: 0px 10px 10px 10px;
+
+	border: 1px solid #c4c4c4;
+	border-radius: 10px;
+
+	cursor: pointer;
+
+	:hover {
+		background-color: rgba(0, 101, 255, 0.2);
+		border: 1px solid #0065ff;
+
+		transform: scale(1.02);
+		transition: all ease 0.7s;
+	}
+`;
+
+const CardTextWrapper = styled.article`
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	align-items: flex-start;
+
+	height: 70px;
+	margin-left: 10px;
+`;
+
+export { WideCardWrapper, CardTextWrapper };

--- a/src/components/UI/molecules/WideCard/WideCard.types.ts
+++ b/src/components/UI/molecules/WideCard/WideCard.types.ts
@@ -1,0 +1,11 @@
+import { CSSProperties } from 'react';
+
+import { AdvantageInformation } from '@common/types';
+
+interface WideCardProps {
+	style?: CSSProperties;
+	imageURL?: string;
+	advantageInfo: AdvantageInformation;
+}
+
+export type { WideCardProps };

--- a/src/components/UI/molecules/WideCard/index.tsx
+++ b/src/components/UI/molecules/WideCard/index.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import type { WideCardProps } from './WideCard.types';
+import { WideCardWrapper, CardTextWrapper } from './WideCard.styles';
+
+import Avatar from '@atoms/Avatar';
+import Label from '@atoms/Label';
+import CategoryLabelList from '@molecules/CategoryLabelList';
+
+const WideCard = ({ style, imageURL, advantageInfo: { userName, categories } }: WideCardProps) => {
+	return (
+		<WideCardWrapper style={style}>
+			<Avatar image={imageURL} />
+			<CardTextWrapper>
+				<Label style={{ marginTop: 0 }} text={userName} />
+				<CategoryLabelList categories={categories} />
+			</CardTextWrapper>
+		</WideCardWrapper>
+	);
+};
+
+export default WideCard;

--- a/src/components/UI/molecules/WideCardList/WideCardList.styles.ts
+++ b/src/components/UI/molecules/WideCardList/WideCardList.styles.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+const WideCardListWrapper = styled.article`
+	display: flex;
+	justify-content: space-between;
+	flex-wrap: wrap;
+`;
+
+export { WideCardListWrapper };

--- a/src/components/UI/molecules/WideCardList/WideCardList.types.ts
+++ b/src/components/UI/molecules/WideCardList/WideCardList.types.ts
@@ -1,0 +1,9 @@
+import { CSSProperties } from 'react';
+
+import { AdvantageInformation } from '@common/types';
+
+interface WideCardListProps {
+	advantageInformations: AdvantageInformation[];
+}
+
+export type { WideCardListProps };

--- a/src/components/UI/molecules/WideCardList/index.tsx
+++ b/src/components/UI/molecules/WideCardList/index.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import type { WideCardListProps } from './WideCardList.types';
+import { WideCardListWrapper } from './WideCardList.styles';
+
+import WideCard from '@molecules/WideCard';
+
+const WideCardList = ({ advantageInformations }: WideCardListProps) => {
+	return (
+		<WideCardListWrapper>
+			{advantageInformations.map(advantageInfo => (
+				<WideCard advantageInfo={advantageInfo} />
+			))}
+		</WideCardListWrapper>
+	);
+};
+
+export default WideCardList;

--- a/src/components/UI/organisms/WideListContainer/WideListContainer.styles.ts
+++ b/src/components/UI/organisms/WideListContainer/WideListContainer.styles.ts
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+const WideListContainerWrapper = styled.article`
+	display: flex;
+	flex-direction: column;
+`;
+
+export { WideListContainerWrapper };

--- a/src/components/UI/organisms/WideListContainer/WideListContainer.types.ts
+++ b/src/components/UI/organisms/WideListContainer/WideListContainer.types.ts
@@ -1,0 +1,12 @@
+import { CSSProperties } from 'react';
+
+import { AdvantageInformation } from '@common/types';
+
+import { LabelButtonProps } from '@molecules/LabelButton/LabelButton.types';
+
+interface WideListContainerProps extends LabelButtonProps {
+	styles?: CSSProperties;
+	advantageInformations: AdvantageInformation[];
+}
+
+export type { WideListContainerProps };

--- a/src/components/UI/organisms/WideListContainer/index.tsx
+++ b/src/components/UI/organisms/WideListContainer/index.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import type { WideListContainerProps } from './WideListContainer.types';
+import { WideListContainerWrapper } from './WideListContainer.styles';
+
+import WideCardList from '@molecules/WideCardList';
+import LabelButton from '@molecules/LabelButton';
+
+const WideListContainer = ({
+	styles,
+	advantageInformations,
+	buttonText,
+	labelText,
+	buttonStyle,
+	labelStyle,
+	wrapperStyle,
+}: WideListContainerProps) => {
+	return (
+		<WideListContainerWrapper style={styles}>
+			<LabelButton
+				buttonText={buttonText}
+				labelText={labelText}
+				buttonStyle={buttonStyle}
+				labelStyle={labelStyle}
+				wrapperStyle={wrapperStyle}
+			/>
+			<WideCardList advantageInformations={advantageInformations} />
+		</WideListContainerWrapper>
+	);
+};
+
+export default WideListContainer;


### PR DESCRIPTION
## 📔 Description

- 아래 Figma 로 만든 card container 를 추가했습니다.
<img width="666" alt="스크린샷 2022-02-01 오전 12 04 04" src="https://user-images.githubusercontent.com/64253365/151817645-3dfebb3a-f561-478c-8ae4-f5c11901e1a8.png">

## 💻 commit

- Avatar component 를 추가했습니다. 6119719
  각자의 프로필 사진을 보여줍니다.

- CategoryLabel component 를 추가했습니다. ede834c
   유저가 추가한 category 를 label 화 했습니다.

- CategoryLabelList component 를 추가했습니다. bf67411
   위 CategoryLabel 을 여러 갯수를 표기합니다. 
   
- Label component 를 추가했습니다. 713b452
   Label (text)을 표기합니다. 
   
- 공통으로 사용될 Advantage inforamation interface 를 추가했습니다. e734a0d

- WideCard component 를 추가했습니다. d582bbf
   유저가 올린 데이터를 card 형태로 보여줍니다.
   
- WideCardList component 를 추가했습니다. 6ff909e
   위 WideCard 를 여러개 표기합니다.
   
- WideListContainer component 를 추가했습니다. 24b5667
   LabelButton, WideCardList 를 포함하여 디자인대로 표기해줍니다.
   
## 📜 Result
<img width="2560" alt="스크린샷 2022-02-01 오전 12 11 48" src="https://user-images.githubusercontent.com/64253365/151818987-4c1adb19-554f-4142-a583-7d722619407e.png">

